### PR TITLE
Add material struct

### DIFF
--- a/src/MinX.jl
+++ b/src/MinX.jl
@@ -2,6 +2,7 @@ module MinX
 
 include("basis.jl")
 include("quadrature.jl")
+include("material.jl")
 include("mesh.jl")
 include("assemble.jl")
 include("convergence.jl")

--- a/src/material.jl
+++ b/src/material.jl
@@ -1,0 +1,39 @@
+export Material, MaterialType, Heat, Elastic, type
+export heat, elastic
+
+# XXX: This enum is only used to determine if B should remain B,
+# or become expanded towards BB. It seems there would be better ways
+# to encode that that are not directly based on the material type?
+@enum MaterialType begin
+    Heat
+    Elastic
+end
+
+struct Material
+    type::MaterialType
+    constitutive::Function
+end
+
+function heat(kappa::Number)
+    constitutive(dim) = kappa * Matrix(I, dim, dim)
+    return Material(Heat, constitutive)
+end
+
+function elastic(E::Number, nu::Number, plane_strain = true)
+    # XXX: If the situation appears where constitutive needs to be
+    # reevaluated while assembling, the if/else should be rearranged.
+    function constitutive(dim)
+        if dim == 1
+            return E * Matrix(I, dim, dim)
+        elseif dim == 2 && plane_strain
+            return E / ((1 + nu) * (1 - 2 * nu)) *
+                   [[1 - nu nu 0]; [nu 1 - nu 0]; [0 0 (1 - 2 * nu) / 2]]
+        elseif dim == 2
+            return E / (1 - nu^2) * [[1 nu 0]; [nu 1 0]; [0 0 (1 - nu) / 2]]
+        end
+    end
+    return Material(Elastic, constitutive)
+end
+
+type(m::Material) = m.type
+constitutive(m::Material, dim) = m.constitutive(dim)

--- a/src/plots.jl
+++ b/src/plots.jl
@@ -50,13 +50,25 @@ end
 function plot_solution_elastic(nelem)
     # TODO: Refactor all these plots together. Its getting out of hand.
     mesh = MinX.Mesh((1, 1), (nelem, nelem))
-    Ke = element_matrix(Elastic, mesh)
+    Ke = element_matrix(elastic(2.5, 0.25), mesh)
 
     boundary =
         (x, y) -> isapprox(x, 0) || isapprox(y, 0) || isapprox(x, 1) || isapprox(y, 1)
     fixed = prescribe(mesh, Ke, 2, boundary)
 
-    u = MinX.solve(mesh, Ke, forcing, fixed)
+    forcing(lambda, mu) =
+        xyz -> [
+            -pi^2 * (
+                -(lambda + 3mu) * sin(pi * xyz[1]) * sin(pi * xyz[2]) +
+                (lambda + mu) * cos(pi * xyz[1]) * cos(pi * xyz[2])
+            ),
+            -pi^2 * (
+                -(lambda + 3mu) * sin(pi * xyz[1]) * sin(pi * xyz[2]) +
+                (lambda + mu) * cos(pi * xyz[1]) * cos(pi * xyz[2])
+            ),
+        ]
+
+    u = MinX.solve(mesh, Ke, forcing(1, 1), fixed)
 
     xs = map(node -> coords(mesh, node)[1], nodes(mesh))[:, 1]
     ys = map(node -> coords(mesh, node)[2], nodes(mesh))[1, :]

--- a/test/test_convergence_rate.jl
+++ b/test/test_convergence_rate.jl
@@ -3,7 +3,7 @@ using MinX
 
 
 struct ConvergenceTest
-    element_type::MinX.ElementType
+    material::Material
     dimension::Integer
     forcing::Function
     fixed_boundary::Function
@@ -14,8 +14,6 @@ struct ConvergenceTest
 end
 
 # This does require Lame parameters lambda = mu = 1 yielding E = 2.5, nu = 0.25.
-# XXX: Set material properties through configurable material.
-# This relies on hardcoded E = 2.5, nu = 0.25 in element itself...
 forcing_elastic_2d(lambda, mu) =
     xyz -> [
         -pi^2 * (
@@ -31,7 +29,7 @@ forcing_elastic_2d(lambda, mu) =
 
 convergence_tests = [
     ConvergenceTest(
-        Heat,
+        heat(1),
         1,
         xyz -> sin(2 * pi * xyz[1]) * (2 * pi)^2,
         x -> isapprox(x, 0) || isapprox(x, 1),
@@ -41,7 +39,7 @@ convergence_tests = [
         (0.99, 2.01),
     ),
     ConvergenceTest(
-        Heat,
+        heat(1),
         2,
         xyz -> sin(pi * xyz[1]) * pi^2 * sin(pi * xyz[2]) * 2,
         (x, y) -> x ≈ 0.0 || x ≈ 1.0 || y ≈ 0.0 || y ≈ 1.0,
@@ -54,7 +52,7 @@ convergence_tests = [
         (0.99, 2.01),
     ),
     ConvergenceTest(
-        Heat,
+        heat(1),
         3,
         xyz ->
             sin(pi * xyz[1]) * pi^2 * sin(pi * xyz[2]) * 2.0 * sin(pi * xyz[3]) * 1.5,
@@ -69,7 +67,7 @@ convergence_tests = [
         (0.99, 2.01),
     ),
     ConvergenceTest(
-        Elastic,
+        elastic(1, 0),
         1,
         xyz -> xyz[1],
         x -> isapprox(x, 0),
@@ -81,7 +79,7 @@ convergence_tests = [
     ConvergenceTest(
         # https://doi.org/10.1007/s00466-023-02282-2
         # TODO: Also implement 'divergent free' example from this paper.
-        Elastic,
+        elastic(2.5, 0.25, true),
         2,
         forcing_elastic_2d(1, 1),
         (x, y) -> x ≈ 0.0 || x ≈ 1.0 || y ≈ 0.0 || y ≈ 1.0,
@@ -105,7 +103,7 @@ convergence_tests = [
     function convergence_test(test::ConvergenceTest)
         delta, l2norm, energy = MinX.convergence_rate(
             test.dimension,
-            test.element_type,
+            test.material,
             test.forcing,
             test.fixed_boundary,
             test.solution,

--- a/test/test_element.jl
+++ b/test/test_element.jl
@@ -5,7 +5,7 @@ using LinearAlgebra
 @testset "Shape func derivative match element size" begin
     for n = 1:4, m = 1:4
         mesh = MinX.Mesh((n, n), (m, m))
-        ke = MinX.element_matrix(Elastic, mesh)
+        ke = MinX.element_matrix(heat(1), mesh)
         @test isapprox(min(ke.B...), -m / (2 * n))
         @test isapprox(max(ke.B...), +m / (2 * n))
         # Determinant of J(acobian) should be physical area/4


### PR DESCRIPTION
* Move material properties in a struct
* Properties are configurable through constructor
* Constructor returns local function to retrieve constitutive equations

The `MaterialType` can almost be removed. Need to find another way to branch on that.